### PR TITLE
chore: removing pipe to devnull as it blocks when regenerating cookie

### DIFF
--- a/run_service.sh
+++ b/run_service.sh
@@ -21,7 +21,7 @@
 if [ "$(git rev-parse --is-inside-work-tree)" = true ]
 then
     # silently stop the existing service, if it exists
-    chmod +x stop_service.sh && ./stop_service.sh > /dev/null 2>&1
+    chmod +x stop_service.sh && ./stop_service.sh
     poetry install
     poetry run python run_service.py
 else


### PR DESCRIPTION
when removing cookie line in local_config.json , stop_service.sh prompts and waits for a new x.com.cookies.json file to placed in the repo root -- without the console logging the script just blocks without any indication to the user